### PR TITLE
Extend process-task-list instructions to run tests and commit

### DIFF
--- a/process-task-list.mdc
+++ b/process-task-list.mdc
@@ -12,7 +12,7 @@ Guidelines for managing task lists in markdown files to track progress on comple
 - **Completion protocol:**  
   1. When you finish a **sub‑task**, immediately mark it as completed by changing `[ ]` to `[x]`.
   2. If **all** subtasks underneath a parent task are now `[x]`, follow this sequence:
-    - **First**: Run the full test suite to ensure nothing is broken
+    - **First**: Run the full test suite (`pytest`, `npm test`, `bin/rails test`, etc.)
     - **Only if all tests pass**: Stage changes (`git add .`)
     - **Clean up**: Remove any temporary files and temporary code before committing
     - **Commit**: Use a descriptive commit message that:


### PR DESCRIPTION
I recently added this instruction to `process-task-list.mdc` and liking it. It makes the AI run test suite and commit changes when all the sub-tasks of a parent task, are completed. Working well for me, but feel free to close if you think it's not very broadly applicable. By the way, I used same instruction to also commit the change here. :)
cc @snarktank 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the task completion process to include running tests, cleaning up temporary files, staging changes, and following a standardized commit procedure before marking parent tasks as complete. The commit message format and required content have also been clarified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->