### PR TITLE
Instruction to format commit message with -m flags

### DIFF
--- a/process-task-list.mdc
+++ b/process-task-list.mdc
@@ -8,7 +8,7 @@ alwaysApply: false
 Guidelines for managing task lists in markdown files to track progress on completing a PRD
 
 ## Task Implementation
-- **One sub-task at a time:** Do **NOT** start the next sub‑task until you ask the user for permission and they say “yes” or "y"
+- **One sub-task at a time:** Do **NOT** start the next sub‑task until you ask the user for permission and they say "yes" or "y"
 - **Completion protocol:**  
   1. When you finish a **sub‑task**, immediately mark it as completed by changing `[ ]` to `[x]`.
   2. If **all** subtasks underneath a parent task are now `[x]`, follow this sequence:
@@ -16,12 +16,17 @@ Guidelines for managing task lists in markdown files to track progress on comple
     - **Only if all tests pass**: Stage changes (`git add .`)
     - **Clean up**: Remove any temporary files and temporary code before committing
     - **Commit**: Use a descriptive commit message that:
-     - Uses conventional commit format (feat:, fix:, refactor:, etc.)
-     - Summarizes what was accomplished in the parent task
-     - Lists key changes and additions
-     - References the task number and PRD context
-  3. Once all the sub-tasks are marked completed and changes have been committed, mark the **parent task** as completed.
-- Stop after each sub‑task and wait for the user’s go‑ahead.
+      - Uses conventional commit format (`feat:`, `fix:`, `refactor:`, etc.)
+      - Summarizes what was accomplished in the parent task
+      - Lists key changes and additions
+      - References the task number and PRD context
+      - **Formats the message as a single-line command using `-m` flags**, e.g.:
+
+        ```
+        git commit -m "feat: add payment validation logic" -m "- Validates card type and expiry" -m "- Adds unit tests for edge cases" -m "Related to T123 in PRD"
+        ```
+  3. Once all the subtasks are marked completed and changes have been committed, mark the **parent task** as completed.
+- Stop after each sub‑task and wait for the user's go‑ahead.
 
 ## Task List Maintenance
 
@@ -29,7 +34,7 @@ Guidelines for managing task lists in markdown files to track progress on comple
    - Mark tasks and subtasks as completed (`[x]`) per the protocol above.
    - Add new tasks as they emerge.
 
-2. **Maintain the “Relevant Files” section:**
+2. **Maintain the "Relevant Files" section:**
    - List every file created or modified.
    - Give each file a one‑line description of its purpose.
 
@@ -42,6 +47,6 @@ When working with task lists, the AI must:
    - Mark each finished **sub‑task** `[x]`.
    - Mark the **parent task** `[x]` once **all** its subtasks are `[x]`.
 3. Add newly discovered tasks.
-4. Keep “Relevant Files” accurate and up to date.
+4. Keep "Relevant Files" accurate and up to date.
 5. Before starting work, check which sub‑task is next.
 6. After implementing a sub‑task, update the file and then pause for user approval.


### PR DESCRIPTION
This is a small improvement to #17. AI was being inconsistent in how commit messages were formatted, often trying to make a super long one-line sentence. This instructs to use -m flags properly.

cc @snarktank 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated commit message guidelines to specify formatting using multiple `-m` flags in the `git commit` command.
  - Added an explicit example for structuring commit messages.
  - Improved wording and punctuation consistency throughout the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->