### PR TITLE
feat: add optional prototype workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Stop wrestling with monolithic AI requests and start guiding your AI collaborato
 
 Building complex features with AI can sometimes feel like a black box. This workflow aims to bring structure, clarity, and control to the process by:
 
-1.  **Defining Scope:** Clearly outlining what needs to be built with a Product Requirement Document (PRD).
-2.  **Detailed Planning:** Breaking down the PRD into a granular, actionable task list.
-3.  **Iterative Implementation:** Guiding the AI to tackle one task at a time, allowing you to review and approve each change.
+1.    **Defining Scope:** Clearly outlining what needs to be built with a Product Requirement Document (PRD).
+2.    **Detailed Planning:** Breaking down the PRD into a granular, actionable task list.
+3.    **Iterative Implementation:** Guiding the AI to tackle one task at a time, allowing you to review and approve each change.
 
 This structured approach helps ensure the AI stays on track, makes it easier to debug issues, and gives you confidence in the generated code.
 
@@ -18,37 +18,41 @@ This structured approach helps ensure the AI stays on track, makes it easier to 
 
 Here's the step-by-step process using the `.mdc` files in this repository:
 
+> **💡 New! Optional Prototype Path:** After creating your PRD, you can now optionally generate a functional prototype to validate concepts quickly before full implementation. See the [Optional: Rapid Prototyping](#optional-rapid-prototyping-🚀) section below.
+
 ### 1️⃣ Create a Product Requirement Document (PRD)
 
 First, lay out the blueprint for your feature. A PRD clarifies what you're building, for whom, and why.
 
 You can create a lightweight PRD directly within Cursor:
 
-1.  Ensure you have the `create-prd.mdc` file from this repository accessible.
-2.  In Cursor's Agent chat, initiate PRD creation:
+1.    Ensure you have the `create-prd.mdc` file from this repository accessible.
+2.    In Cursor's Agent chat, initiate PRD creation:
 
-    ```
-    Use @create-prd.mdc
-    Here's the feature I want to build: [Describe your feature in detail]
-    Reference these files to help you: [Optional: @file1.py @file2.ts]
-    ```
-    *(Pro Tip: For complex PRDs, using MAX mode in Cursor is highly recommended if your budget allows for more comprehensive generation.)*
+      ```
+      Use @create-prd.mdc
+      Here's the feature I want to build: [Describe your feature in detail]
+      Reference these files to help you: [Optional: @file1.py @file2.ts]
+      ```
 
-    ![Example of initiating PRD creation](https://pbs.twimg.com/media/Go6DDlyX0AAS7JE?format=jpg&name=large)
+      _(Pro Tip: For complex PRDs, using MAX mode in Cursor is highly recommended if your budget allows for more comprehensive generation.)_
+
+      ![Example of initiating PRD creation](https://pbs.twimg.com/media/Go6DDlyX0AAS7JE?format=jpg&name=large)
 
 ### 2️⃣ Generate Your Task List from the PRD
 
 With your PRD drafted (e.g., `MyFeature-PRD.md`), the next step is to generate a detailed, step-by-step implementation plan for your AI Developer.
 
-1.  Ensure you have `generate-tasks.mdc` accessible.
-2.  In Cursor's Agent chat, use the PRD to create tasks:
+1.    Ensure you have `generate-tasks.mdc` accessible.
+2.    In Cursor's Agent chat, use the PRD to create tasks:
 
-    ```
-    Now take @MyFeature-PRD.md and create tasks using @generate-tasks.mdc
-    ```
-    *(Note: Replace `@MyFeature-PRD.md` with the actual filename of the PRD you generated in step 1.)*
+      ```
+      Now take @MyFeature-PRD.md and create tasks using @generate-tasks.mdc
+      ```
 
-    ![Example of generating tasks from PRD](https://pbs.twimg.com/media/Go6FITbWkAA-RCT?format=jpg&name=medium)
+      _(Note: Replace `@MyFeature-PRD.md` with the actual filename of the PRD you generated in step 1.)_
+
+      ![Example of generating tasks from PRD](https://pbs.twimg.com/media/Go6FITbWkAA-RCT?format=jpg&name=medium)
 
 ### 3️⃣ Examine Your Task List
 
@@ -60,23 +64,25 @@ You'll now have a well-structured task list, often with tasks and sub-tasks, rea
 
 To ensure methodical progress and allow for verification, we'll use `process-task-list.mdc`. This command instructs the AI to focus on one task at a time and wait for your go-ahead before moving to the next.
 
-1.  Create or ensure you have the `process-task-list.mdc` file accessible.
-2.  In Cursor's Agent chat, tell the AI to start with the first task (e.g., `1.1`):
+1.    Create or ensure you have the `process-task-list.mdc` file accessible.
+2.    In Cursor's Agent chat, tell the AI to start with the first task (e.g., `1.1`):
 
-    ```
-    Please start on task 1.1 and use @process-task-list.mdc
-    ```
-    *(Important: You only need to reference `@process-task-list.mdc` for the *first* task. The instructions within it guide the AI for subsequent tasks.)*
+      ```
+      Please start on task 1.1 and use @process-task-list.mdc
+      ```
 
-    The AI will attempt the task and then prompt you to review.
+      *(Important: You only need to reference `@process-task-list.mdc` for the *first* task. The instructions within it guide the AI for subsequent tasks.)*
 
-    ![Example of starting on a task with process-task-list.mdc](https://pbs.twimg.com/media/Go6I41KWcAAAlHc?format=jpg&name=medium)
+      The AI will attempt the task and then prompt you to review.
+
+      ![Example of starting on a task with process-task-list.mdc](https://pbs.twimg.com/media/Go6I41KWcAAAlHc?format=jpg&name=medium)
 
 ### 5️⃣ Review, Approve, and Progress ✅
 
 As the AI completes each task, you review the changes.
-*   If the changes are good, simply reply with "yes" (or a similar affirmative) to instruct the AI to mark the task complete and move to the next one.
-*   If changes are needed, provide feedback to the AI to correct the current task before moving on.
+
+- If the changes are good, simply reply with "yes" (or a similar affirmative) to instruct the AI to mark the task complete and move to the next one.
+- If changes are needed, provide feedback to the AI to correct the current task before moving on.
 
 You'll see a satisfying list of completed items grow, providing a clear visual of your feature coming to life!
 
@@ -90,41 +96,120 @@ If you'd like to see this in action, I demonstrated it on [Claire Vo's "How I AI
 
 ![Demonstration of AI Dev Tasks on How I AI Podcast](https://img.youtube.com/vi/fD4ktSkNCw4/maxresdefault.jpg)
 
+## Optional: Rapid Prototyping 🚀
+
+**New!** Before diving into full implementation, you can now create a functional prototype to validate your concepts quickly. This is especially valuable for:
+
+- Testing user experience assumptions
+- Gathering stakeholder feedback early
+- Demonstrating value proposition with mocked data
+- Validating technical approaches
+
+### When to Use Prototyping
+
+Consider prototyping when:
+
+- Your feature involves significant user interaction
+- You need stakeholder buy-in before full development
+- You want to test multiple approaches quickly
+- The PRD has assumptions that need validation
+
+### Prototype Workflow
+
+After creating your PRD (Step 1), you can optionally create a prototype:
+
+**Step 1.5: Generate Prototype Scope and Tasks**
+
+1. Ensure you have the `generate-prototype.mdc` file accessible.
+2. In Cursor's Agent chat, reference your PRD:
+
+      ```
+      Use @generate-prototype.mdc to create a prototype for @MyFeature-PRD.md
+      ```
+
+      The AI will ask clarifying questions about:
+
+      - Technology stack preferences
+      - Which core features to prioritize
+      - Data mocking strategy
+      - Desired level of polish
+
+3. Review the generated prototype scope document and approve it.
+
+4. The AI will then create a prototype task list that works with your existing `process-task-list.mdc` workflow.
+
+**Step 1.6: Build the Prototype**
+
+Use the generated prototype task list just like regular tasks:
+
+```
+Please start on task 1.1 and use @process-task-list.mdc
+```
+
+The prototype tasks are designed to be completed in 1-3 days, focusing on:
+
+- Core user workflows with mocked data
+- Functional frontend components
+- Quick validation over perfect code
+
+**Step 1.7: Validate and Iterate**
+
+- Share the prototype with stakeholders
+- Gather feedback on user experience
+- Validate assumptions from the PRD
+- Use insights to refine your PRD or task list
+
+### Prototype vs. Full Implementation
+
+| Aspect       | Prototype           | Full Implementation         |
+| ------------ | ------------------- | --------------------------- |
+| **Timeline** | 1-3 days            | Weeks to months             |
+| **Data**     | Mocked/hardcoded    | Real APIs and databases     |
+| **Polish**   | Functional, scrappy | Production-ready            |
+| **Testing**  | Basic validation    | Comprehensive test coverage |
+| **Purpose**  | Validate concepts   | Ship to users               |
+
+The prototype workflow seamlessly integrates with your existing process - you can prototype first, then continue with Steps 2-5 for full implementation, using insights from the prototype to inform your development.
+
 ## 🗂️ Files in this Repository
 
-*   **`create-prd.mdc`**: Guides the AI in generating a Product Requirement Document for your feature.
-*   **`generate-tasks-from-prd.mdc`**: Takes a PRD markdown file as input and helps the AI break it down into a detailed, step-by-step implementation task list.
-*   **`process-task-list.mdc`**: Instructs the AI on how to process the generated task list, tackling one task at a time and waiting for your approval before proceeding. (This file also contains logic for the AI to mark tasks as complete).
+- **`create-prd.mdc`**: Guides the AI in generating a Product Requirement Document for your feature.
+- **`generate-tasks.mdc`**: Takes a PRD markdown file as input and helps the AI break it down into a detailed, step-by-step implementation task list.
+- **`generate-prototype.mdc`**: _(New!)_ Creates a prototype scope document and task list for rapid validation of core concepts with mocked data.
+- **`process-task-list.mdc`**: Instructs the AI on how to process the generated task lists, tackling one task at a time and waiting for your approval before proceeding. (This file also contains logic for the AI to mark tasks as complete).
 
 ## 🌟 Benefits
 
-*   **Structured Development:** Enforces a clear process from idea to code.
-*   **Step-by-Step Verification:** Allows you to review and approve AI-generated code at each small step, ensuring quality and control.
-*   **Manages Complexity:** Breaks down large features into smaller, digestible tasks for the AI, reducing the chance of it getting lost or generating overly complex, incorrect code.
-*   **Improved Reliability:** Offers a more dependable approach to leveraging AI for significant development work compared to single, large prompts.
-*   **Clear Progress Tracking:** Provides a visual representation of completed tasks, making it easy to see how much has been done and what's next.
+- **Structured Development:** Enforces a clear process from idea to code.
+- **Step-by-Step Verification:** Allows you to review and approve AI-generated code at each small step, ensuring quality and control.
+- **Manages Complexity:** Breaks down large features into smaller, digestible tasks for the AI, reducing the chance of it getting lost or generating overly complex, incorrect code.
+- **Improved Reliability:** Offers a more dependable approach to leveraging AI for significant development work compared to single, large prompts.
+- **Clear Progress Tracking:** Provides a visual representation of completed tasks, making it easy to see how much has been done and what's next.
+- **Rapid Validation:** _(New!)_ Optional prototyping workflow allows you to validate concepts quickly with stakeholders before full implementation.
+- **Risk Reduction:** Catch UX issues and technical challenges early through scrappy prototypes rather than during full development.
 
 ## 🛠️ How to Use
 
-1.  **Clone or Download:** Get these `.mdc` files into your project or a central location where Cursor can access them.
-2.  **Follow the Workflow:** Systematically use the `.mdc` files in Cursor's Agent chat as described in the 5-step workflow above.
-3.  **Adapt and Iterate:**
-    *   Feel free to modify the prompts within the `.mdc` files to better suit your specific needs or coding style.
-    *   If the AI struggles with a task, try rephrasing your initial feature description or breaking down tasks even further.
+1.    **Clone or Download:** Get these `.mdc` files into your project or a central location where Cursor can access them.
+2.    **Follow the Workflow:** Systematically use the `.mdc` files in Cursor's Agent chat as described in the 5-step workflow above.
+3.    **Adapt and Iterate:**
+      - Feel free to modify the prompts within the `.mdc` files to better suit your specific needs or coding style.
+      - If the AI struggles with a task, try rephrasing your initial feature description or breaking down tasks even further.
 
 ## 💡 Tips for Success
 
-*   **Be Specific:** The more context and clear instructions you provide (both in your initial feature description and any clarifications), the better the AI's output will be.
-*   **MAX Mode for PRDs:** As mentioned, using MAX mode in Cursor for PRD creation (`create-prd.mdc`) can yield more thorough and higher-quality results if your budget supports it.
-*   **Correct File Tagging:** Always ensure you're accurately tagging the PRD filename (e.g., `@MyFeature-PRD.md`) when generating tasks.
-*   **Patience and Iteration:** AI is a powerful tool, but it's not magic. Be prepared to guide, correct, and iterate. This workflow is designed to make that iteration process smoother.
+- **Be Specific:** The more context and clear instructions you provide (both in your initial feature description and any clarifications), the better the AI's output will be.
+- **MAX Mode for PRDs:** As mentioned, using MAX mode in Cursor for PRD creation (`create-prd.mdc`) can yield more thorough and higher-quality results if your budget supports it.
+- **Correct File Tagging:** Always ensure you're accurately tagging the PRD filename (e.g., `@MyFeature-PRD.md`) when generating tasks.
+- **Patience and Iteration:** AI is a powerful tool, but it's not magic. Be prepared to guide, correct, and iterate. This workflow is designed to make that iteration process smoother.
 
 ## 🤝 Contributing
 
 Got ideas to improve these `.mdc` files or have new ones that fit this workflow? Contributions are welcome!
 Please feel free to:
-*   Open an issue to discuss changes or suggest new features.
-*   Submit a pull request with your enhancements.
+
+- Open an issue to discuss changes or suggest new features.
+- Submit a pull request with your enhancements.
 
 ---
 

--- a/generate-prototype.mdc
+++ b/generate-prototype.mdc
@@ -1,0 +1,103 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+# Rule: Generating a Prototype Scope and Task List
+
+## Goal
+
+To guide an AI assistant in creating a prototype scope document and corresponding task list based on an existing PRD. The prototype should be a scrappy, functional version that demonstrates core functionality with mocked data, allowing developers and stakeholders to quickly validate concepts before full implementation.
+
+## Prerequisites
+
+This rule should be used **after**:
+1. A PRD has been created using [create-prd.mdc](mdc:create-prd.mdc)
+2. (Optional) Tasks have been generated using [generate-tasks.mdc](mdc:generate-tasks.mdc)
+
+Note: The prototype can be created with just the PRD, as it focuses on high-level functionality validation rather than detailed implementation.
+
+## Process
+
+1. **Receive PRD Reference:** The user points the AI to a specific PRD file to base the prototype on.
+2. **Analyze Requirements:** The AI reads and analyzes the PRD's functional requirements, user stories, and goals to understand the core functionality that needs validation.
+3. **Ask Prototype Clarification Questions:** Before creating the scope, the AI *must* ask clarifying questions about the prototype approach and priorities. Make sure to provide options in letter/number lists so the user can respond easily with their selections.
+4. **Generate Prototype Scope Document:** Create a focused scope document that defines what will be built, what will be mocked, and success criteria.
+5. **Generate Prototype Task List:** Create a task list specifically for building the prototype that can be used with [process-task-list.mdc](mdc:process-task-list.mdc).
+6. **Save Documents:** Save both the scope and task list in the `/tasks/` directory.
+
+## Output Documents
+
+The generated documents should include:
+
+1. **Prototype Scope Document** (`prototype-scope-[prd-name].md`):
+   - Purpose and validation goals
+   - Features to implement vs. features to mock/skip
+   - Technology stack and approach
+   - Data mocking strategy
+   - Success criteria for the prototype
+   - Timeline and effort estimates
+
+2. **Prototype Task List** (`prototype-tasks-[prd-name].md`):
+   - High-level parent tasks for building the prototype
+   - Detailed sub-tasks following the same format as [generate-tasks.mdc](mdc:generate-tasks.mdc)
+   - Relevant files section with expected prototype files
+   - Compatible with [process-task-list.mdc](mdc:process-task-list.mdc) workflow
+
+## Output
+
+* **Format:** Two Markdown documents
+* **Location:** `/tasks/`
+* **Files:**
+  - `prototype-scope-[prd-name].md` - Defines what to build and how
+  - `prototype-tasks-[prd-name].md` - Step-by-step implementation tasks
+
+## Scope Document Guidelines
+
+1. **Purpose-Driven:** Clearly state why this prototype is being built and what questions it should answer.
+
+2. **Selective Feature Implementation:**
+   - Choose 2-4 core features that best demonstrate the value proposition
+   - Clearly distinguish between "implement," "mock," and "skip"
+   - Focus on user-facing functionality over backend complexity
+
+3. **Scrappy Approach:**
+   - Prioritize speed to feedback over code quality
+   - Use shortcuts and simplifications where possible
+   - Document what would be different in production
+
+4. **Clear Success Criteria:**
+   - Define specific validation goals
+   - Include criteria for stakeholder feedback
+   - Set realistic timeline expectations
+
+## Task List Guidelines
+
+1. **Compatible Format:** Follow the exact task structure from [generate-tasks.mdc](mdc:generate-tasks.mdc) so it works with [process-task-list.mdc](mdc:process-task-list.mdc).
+
+2. **Prototype-Focused Tasks:**
+   - Emphasize quick setup and rapid iteration
+   - Include mocking and simulation tasks
+   - Focus on frontend/user-facing components
+
+3. **Relevant Files Section:**
+   - List expected prototype files with clear purposes
+   - Include simple test files for core functionality
+   - Suggest file structure that supports rapid development
+
+## Success Criteria
+
+A successful prototype scope and task list should:
+- Define clear validation goals that align with PRD objectives
+- Create an implementable plan that can be completed in 1-3 days
+- Enable rapid feedback collection from stakeholders and users
+- Focus on core value demonstration over comprehensive feature coverage
+- Integrate seamlessly with the existing task processing workflow
+
+## Final Instructions
+
+1. **Generate both documents:** Always create both the scope document and task list
+2. **Get user approval:** Present the scope document first and get approval before finalizing the task list
+3. **Maintain simplicity:** Keep the prototype focused and scrappy - resist feature creep
+4. **Enable rapid iteration:** Structure tasks to allow for quick changes based on feedback
+5. **Link to PRD:** Clearly connect prototype goals back to PRD requirements and success metrics


### PR DESCRIPTION
- Add generate-prototype.mdc cursor rule for rapid prototyping, enabling validation of concepts with mocked data before full implementation run with process-tasks.mdc

- Update README with prototype workflow info