### PR TITLE
docs (markdownlint): Add linter, fix formatting

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,18 @@
+{
+  // https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md
+  "default": true,
+  // Trailing spaces
+  "MD009": false,
+  // Line length (default: 80)
+  "MD013": false,
+  // Duplicate headings (e.g., nested headings)
+  "MD024": false,
+  // Ordered list item prefix
+  "MD029": {
+    "style": "ordered"
+  },
+  // Fenced code blocks should be surrounded by blank lines
+  "MD031": false,
+  // Empahsis as heading (e.g., table of contents)
+  "MD036": false
+}

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -13,6 +13,6 @@
   },
   // Fenced code blocks should be surrounded by blank lines
   "MD031": false,
-  // Empahsis as heading (e.g., table of contents)
+  // Emphasis as heading (e.g., table of contents)
   "MD036": false
 }

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Stop wrestling with monolithic AI requests and start guiding your AI collaborato
 
 Building complex features with AI can sometimes feel like a black box. This workflow aims to bring structure, clarity, and control to the process by:
 
-1.  **Defining Scope:** Clearly outlining what needs to be built with a Product Requirement Document (PRD).
-2.  **Detailed Planning:** Breaking down the PRD into a granular, actionable task list.
-3.  **Iterative Implementation:** Guiding the AI to tackle one task at a time, allowing you to review and approve each change.
+1. **Defining Scope:** Clearly outlining what needs to be built with a Product Requirement Document (PRD).
+2. **Detailed Planning:** Breaking down the PRD into a granular, actionable task list.
+3. **Iterative Implementation:** Guiding the AI to tackle one task at a time, allowing you to review and approve each change.
 
 This structured approach helps ensure the AI stays on track, makes it easier to debug issues, and gives you confidence in the generated code.
 
@@ -24,10 +24,10 @@ First, lay out the blueprint for your feature. A PRD clarifies what you're build
 
 You can create a lightweight PRD directly within Cursor:
 
-1.  Ensure you have the `create-prd.mdc` file from this repository accessible.
-2.  In Cursor's Agent chat, initiate PRD creation:
+1. Ensure you have the `create-prd.mdc` file from this repository accessible.
+2. In Cursor's Agent chat, initiate PRD creation:
 
-    ```
+    ```text
     Use @create-prd.mdc
     Here's the feature I want to build: [Describe your feature in detail]
     Reference these files to help you: [Optional: @file1.py @file2.ts]
@@ -40,10 +40,10 @@ You can create a lightweight PRD directly within Cursor:
 
 With your PRD drafted (e.g., `MyFeature-PRD.md`), the next step is to generate a detailed, step-by-step implementation plan for your AI Developer.
 
-1.  Ensure you have `generate-tasks.mdc` accessible.
-2.  In Cursor's Agent chat, use the PRD to create tasks:
+1. Ensure you have `generate-tasks.mdc` accessible.
+2. In Cursor's Agent chat, use the PRD to create tasks:
 
-    ```
+    ```text
     Now take @MyFeature-PRD.md and create tasks using @generate-tasks.mdc
     ```
     *(Note: Replace `@MyFeature-PRD.md` with the actual filename of the PRD you generated in step 1.)*
@@ -60,10 +60,10 @@ You'll now have a well-structured task list, often with tasks and sub-tasks, rea
 
 To ensure methodical progress and allow for verification, we'll use `process-task-list.mdc`. This command instructs the AI to focus on one task at a time and wait for your go-ahead before moving to the next.
 
-1.  Create or ensure you have the `process-task-list.mdc` file accessible.
-2.  In Cursor's Agent chat, tell the AI to start with the first task (e.g., `1.1`):
+1. Create or ensure you have the `process-task-list.mdc` file accessible.
+2. In Cursor's Agent chat, tell the AI to start with the first task (e.g., `1.1`):
 
-    ```
+    ```text
     Please start on task 1.1 and use @process-task-list.mdc
     ```
     *(Important: You only need to reference `@process-task-list.mdc` for the *first* task. The instructions within it guide the AI for subsequent tasks.)*
@@ -75,8 +75,9 @@ To ensure methodical progress and allow for verification, we'll use `process-tas
 ### 5️⃣ Review, Approve, and Progress ✅
 
 As the AI completes each task, you review the changes.
-*   If the changes are good, simply reply with "yes" (or a similar affirmative) to instruct the AI to mark the task complete and move to the next one.
-*   If changes are needed, provide feedback to the AI to correct the current task before moving on.
+
+* If the changes are good, simply reply with "yes" (or a similar affirmative) to instruct the AI to mark the task complete and move to the next one.
+* If changes are needed, provide feedback to the AI to correct the current task before moving on.
 
 You'll see a satisfying list of completed items grow, providing a clear visual of your feature coming to life!
 
@@ -92,39 +93,41 @@ If you'd like to see this in action, I demonstrated it on [Claire Vo's "How I AI
 
 ## 🗂️ Files in this Repository
 
-*   **`create-prd.mdc`**: Guides the AI in generating a Product Requirement Document for your feature.
-*   **`generate-tasks-from-prd.mdc`**: Takes a PRD markdown file as input and helps the AI break it down into a detailed, step-by-step implementation task list.
-*   **`process-task-list.mdc`**: Instructs the AI on how to process the generated task list, tackling one task at a time and waiting for your approval before proceeding. (This file also contains logic for the AI to mark tasks as complete).
+* **`create-prd.mdc`**: Guides the AI in generating a Product Requirement Document for your feature.
+* **`generate-tasks-from-prd.mdc`**: Takes a PRD markdown file as input and helps the AI break it down into a detailed, step-by-step implementation task list.
+* **`process-task-list.mdc`**: Instructs the AI on how to process the generated task list, tackling one task at a time and waiting for your approval before proceeding. (This file also contains logic for the AI to mark tasks as complete).
 
 ## 🌟 Benefits
 
-*   **Structured Development:** Enforces a clear process from idea to code.
-*   **Step-by-Step Verification:** Allows you to review and approve AI-generated code at each small step, ensuring quality and control.
-*   **Manages Complexity:** Breaks down large features into smaller, digestible tasks for the AI, reducing the chance of it getting lost or generating overly complex, incorrect code.
-*   **Improved Reliability:** Offers a more dependable approach to leveraging AI for significant development work compared to single, large prompts.
-*   **Clear Progress Tracking:** Provides a visual representation of completed tasks, making it easy to see how much has been done and what's next.
+* **Structured Development:** Enforces a clear process from idea to code.
+* **Step-by-Step Verification:** Allows you to review and approve AI-generated code at each small step, ensuring quality and control.
+* **Manages Complexity:** Breaks down large features into smaller, digestible tasks for the AI, reducing the chance of it getting lost or generating overly complex, incorrect code.
+* **Improved Reliability:** Offers a more dependable approach to leveraging AI for significant development work compared to single, large prompts.
+* **Clear Progress Tracking:** Provides a visual representation of completed tasks, making it easy to see how much has been done and what's next.
 
 ## 🛠️ How to Use
 
-1.  **Clone or Download:** Get these `.mdc` files into your project or a central location where Cursor can access them.
-2.  **Follow the Workflow:** Systematically use the `.mdc` files in Cursor's Agent chat as described in the 5-step workflow above.
-3.  **Adapt and Iterate:**
-    *   Feel free to modify the prompts within the `.mdc` files to better suit your specific needs or coding style.
-    *   If the AI struggles with a task, try rephrasing your initial feature description or breaking down tasks even further.
+1. **Clone or Download:** Get these `.mdc` files into your project or a central location where Cursor can access them.
+2. **Follow the Workflow:** Systematically use the `.mdc` files in Cursor's Agent chat as described in the 5-step workflow above.
+3. **Adapt and Iterate:**
+    * Feel free to modify the prompts within the `.mdc` files to better suit your specific needs or coding style.
+    * If the AI struggles with a task, try rephrasing your initial feature description or breaking down tasks even further.
 
 ## 💡 Tips for Success
 
-*   **Be Specific:** The more context and clear instructions you provide (both in your initial feature description and any clarifications), the better the AI's output will be.
-*   **MAX Mode for PRDs:** As mentioned, using MAX mode in Cursor for PRD creation (`create-prd.mdc`) can yield more thorough and higher-quality results if your budget supports it.
-*   **Correct File Tagging:** Always ensure you're accurately tagging the PRD filename (e.g., `@MyFeature-PRD.md`) when generating tasks.
-*   **Patience and Iteration:** AI is a powerful tool, but it's not magic. Be prepared to guide, correct, and iterate. This workflow is designed to make that iteration process smoother.
+* **Be Specific:** The more context and clear instructions you provide (both in your initial feature description and any clarifications), the better the AI's output will be.
+* **MAX Mode for PRDs:** As mentioned, using MAX mode in Cursor for PRD creation (`create-prd.mdc`) can yield more thorough and higher-quality results if your budget supports it.
+* **Correct File Tagging:** Always ensure you're accurately tagging the PRD filename (e.g., `@MyFeature-PRD.md`) when generating tasks.
+* **Patience and Iteration:** AI is a powerful tool, but it's not magic. Be prepared to guide, correct, and iterate. This workflow is designed to make that iteration process smoother.
 
 ## 🤝 Contributing
 
 Got ideas to improve these `.mdc` files or have new ones that fit this workflow? Contributions are welcome!
+
 Please feel free to:
-*   Open an issue to discuss changes or suggest new features.
-*   Submit a pull request with your enhancements.
+
+* Open an issue to discuss changes or suggest new features.
+* Submit a pull request with your enhancements.
 
 ---
 


### PR DESCRIPTION
 Hi @snarktank!

Added some standard [markdownlint](https://github.com/DavidAnson/markdownlint) rules codified in `.markdownlint.jsonc` with the following changes:

1. Fixed list marker spacing: Changed inconsistent 2 and 3 space indentation after list markers (*, 1.) to the standard 1 space
2. Added language specification: Added text language identifier to fenced code blocks that were missing it
3. Added blank lines: Added proper blank lines around lists where required

Let me know what you think 🙏 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved formatting and consistency in the README, including compact numbered lists and uniform bullet points.
  - Enhanced code block clarity by specifying the language identifier.
- **Chores**
  - Added a configuration file to customize markdown linting rules for better markdown style enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->