### PR TITLE
feat: improve Claude Code setup and add update workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Purpose
+
+This is the AI Dev Tasks repository - a collection of markdown workflow files designed to help AI assistants systematically build features through structured PRDs and task lists. This repository itself contains the workflow templates, not user implementations.
+
+## Core Workflow Files
+
+The repository contains four essential workflow files:
+
+1. **create-prd.md**: Guides PRD creation with clarifying questions
+2. **generate-tasks.md**: Converts PRDs into detailed task lists
+3. **process-task-list.md**: Manages systematic task execution with checkpoints
+4. **update-ai-dev-tasks.md**: Updates workflow files to the latest version from upstream
+
+## Workflow Process
+
+### 1. PRD Creation
+When asked to create a PRD or plan a feature:
+- Use `create-prd.md` to guide the process
+- Ask clarifying questions before writing the PRD
+- Save PRDs as `/tasks/[n]-prd-[feature-name].md` (e.g., `0001-prd-user-auth.md`)
+- Use 4-digit zero-padded sequence numbers starting from 0001
+
+### 2. Task Generation
+When converting a PRD to tasks:
+- Use `generate-tasks.md` to create structured task lists
+- First generate high-level parent tasks and wait for user confirmation ("Go")
+- Then generate detailed sub-tasks
+- Save as `/tasks/tasks-[prd-file-name].md`
+- Include a "Relevant Files" section listing all files to be created/modified
+
+### 3. Task Processing
+When implementing tasks:
+- Use `process-task-list.md` for systematic execution
+- Complete one sub-task at a time
+- Mark tasks with [x] immediately after completion
+- Wait for user approval ("yes" or "y") before proceeding to next task
+- When all sub-tasks under a parent are complete:
+  - Run tests if available
+  - Stage changes with `git add .`
+  - Create descriptive commits
+  - Mark parent task as complete
+
+### 4. Updating Workflow Files
+When asked to update the AI Dev Tasks workflow:
+- Use `update-ai-dev-tasks.md` to fetch latest versions from upstream
+- Preserves user's PRDs and task lists in `/tasks/`
+- Updates only the core workflow files
+- May update command files if needed
+
+## Directory Structure
+
+```
+/tasks/              # Store all PRDs and task lists here
+  0001-prd-*.md      # PRD files with sequential numbering
+  tasks-0001-*.md    # Corresponding task lists
+```
+
+Create the `/tasks/` directory if it doesn't exist when saving the first PRD.
+
+## Repository Maintenance
+
+When working on this repository itself (not implementing it in other projects):
+
+### Adding New Features
+- New workflow files should follow the naming pattern: `[action]-[target].md`
+- Update README.md to document new workflows
+- Add new workflows to this CLAUDE.md file
+- Ensure new workflows follow the established pattern of clear rules and process steps
+
+### Updating Documentation
+- Keep examples in README.md clear and concise
+- Maintain consistency in terminology across all files
+- Update the Claude Code section when command structure changes
+
+### Version Control
+- This repository is maintained at https://github.com/snarktank/ai-dev-tasks
+- Pull requests should include clear descriptions of workflow improvements
+- Test workflow changes in actual projects before proposing updates

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ If you'd like to see this in action, I demonstrated it on [Claire Vo's "How I AI
 * **`create-prd.md`**: Guides the AI in generating a Product Requirement Document for your feature.
 * **`generate-tasks.md`**: Takes a PRD markdown file as input and helps the AI break it down into a detailed, step-by-step implementation task list.
 * **`process-task-list.md`**: Instructs the AI on how to process the generated task list, tackling one task at a time and waiting for your approval before proceeding. (This file also contains logic for the AI to mark tasks as complete).
+* **`update-ai-dev-tasks.md`**: Helps the AI update your workflow files to the latest version from the original repository.
 
 ## 🌟 Benefits
 
@@ -131,39 +132,17 @@ Cursor users can follow the workflow described above, using the `.md` files dire
 
 To use these tools with Claude Code:
 
-1. **Copy files to your repo**: Copy the three `.md` files to a subdirectory in your project (e.g., `/ai-dev-tasks`)
+```
+Create Claude commands in .claude/commands/ from https://github.com/snarktank/ai-dev-tasks
+```
 
-2. **Reference in CLAUDE.md**: Add these lines to your project's `./CLAUDE.md` file:
-   ```
-   # AI Dev Tasks
-   Use these files when I request structured feature development using PRDs:
-   /ai-dev-tasks/create-prd.md
-   /ai-dev-tasks/generate-tasks.md
-   /ai-dev-tasks/process-task-list.md
-   ```
+Claude will create self-contained command files that include all the workflow instructions:
+- `/create-prd` - Generate Product Requirements Documents
+- `/generate-tasks` - Break down PRDs into task lists
+- `/process-task-list` - Process tasks one at a time
+- `/update-ai-dev-tasks` - Update commands from upstream
 
-3. **Create custom commands** (optional): For easier access, create these files in `.claude/commands/`:
-   - `.claude/commands/create-prd.md` with content:
-     ```
-     Please use the structured workflow in /ai-dev-tasks/create-prd.md to help me create a PRD for a new feature.
-     ```
-   - `.claude/commands/generate-tasks.md` with content:
-     ```
-     Please generate tasks from the PRD using /ai-dev-tasks/generate-tasks.md
-     If not explicitly told which PRD to use, generate a list of PRDs and ask the user to select one under `/tasks` or create a new one using `create-prd.md`:
-     - assume it's stored under `/tasks` and has a filename starting with `[n]-prd-` (e.g., `0001-prd-[name].md`)
-     - it should not already have a corresponding task list in `/tasks` (e.g., `tasks-0001-prd-[name].md`)
-     - **always** ask the user to confirm the PRD file name before proceeding
-     Make sure to provide options in number lists so I can respond easily (if multiple options).
-     ```
-   - `.claude/commands/process-task-list.md` with content:
-     ```
-     Please process the task list using /ai-dev-tasks/process-task-list.md
-     ```
-
-   Make sure to restart Claude Code after adding these files (`/exit`).
-   Then use commands like `/create-prd` to quickly start the workflow.
-   Note: This setup can also be adopted for a global level across all your projects, please refer to the Claude Code documentation [here](https://docs.anthropic.com/en/docs/claude-code/memory) and [here](https://docs.anthropic.com/en/docs/claude-code/common-workflows#create-personal-slash-commands).
+After setup, restart Claude Code (`/exit`) to activate the commands.
 
 ### Other Tools
 

--- a/update-ai-dev-tasks.md
+++ b/update-ai-dev-tasks.md
@@ -1,0 +1,49 @@
+# Rule: Update AI Dev Tasks from Upstream
+
+## Goal
+
+To update the AI Dev Tasks workflow files in your project with the latest version from the original repository, ensuring you have the newest features and improvements.
+
+## Process
+
+When asked to update the AI Dev Tasks workflow, the AI should:
+
+1. **Check Current Setup:**
+   - Verify the location of the ai-dev-tasks files in the current project (typically `/ai-dev-tasks/`)
+   - Note any local modifications if they exist
+
+2. **Fetch Latest Version:**
+   - Download the latest files from the original repository:
+     - `create-prd.md`
+     - `generate-tasks.md`
+     - `process-task-list.md`
+     - `update-ai-dev-tasks.md` (this file)
+   - Source: https://github.com/snarktank/ai-dev-tasks
+
+3. **Update Files:**
+   - Replace the existing workflow files with the latest versions
+   - Preserve the `/tasks/` directory and any existing PRDs/task lists
+   - Do NOT modify any user-created PRDs or task lists
+
+4. **Update Commands (if needed):**
+   - Check if the command structure in `.claude/commands/` needs updating
+   - Update command files if new workflows have been added or existing ones changed
+
+5. **Report Changes:**
+   - Inform the user about which files were updated
+   - Note if any new workflow files were added
+   - Mention if command updates are recommended
+
+## Important Notes
+
+- This process only updates the core workflow files, not user-created content
+- Existing PRDs and task lists in `/tasks/` are never modified
+- If local modifications exist, ask the user before overwriting
+- After updating, the user should restart Claude Code (`/exit`) if commands were updated
+
+## Usage
+
+To trigger an update, the user can simply say:
+- "Update the AI Dev Tasks workflow files"
+- "Get the latest version of AI Dev Tasks"
+- "Update ai-dev-tasks from upstream"


### PR DESCRIPTION
- Simplify Claude Code setup to single command for user convenience
- Add actionable setup details for Claude to execute when fetching the GitHub URL
- Create update-ai-dev-tasks.md workflow for keeping templates current
- Add CLAUDE.md for repository-specific guidance

The setup now provides both ease-of-use (one command) and reliability (explicit instructions for Claude). Users can update their workflow files anytime using the new /update-ai-dev-tasks command.

Addresses reviewer concerns about circular references while maintaining simple UX.